### PR TITLE
import instead of require

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,7 @@ import { createId } from "@paralleldrive/cuid2"
 // const getSocketHost = require('@uppy/utils/lib/getSocketHost');
 import settle from "@uppy/utils/lib/settle"
 import "@uppy/utils/lib/RateLimitedQueue"
-const { DirectUpload } = require("@rails/activestorage")
+import { DirectUpload } from "@rails/activestorage"
 
 export default class ActiveStorageUpload extends BasePlugin {
   constructor(uppy, opts) {


### PR DESCRIPTION
Will play nicely with modern tooling. I needed this as Vite Ruby's production build uses Rollup.js where require() will not work out of the box.

Thanks for your initial fix btw. That made it compile already :-).